### PR TITLE
Log the sentinels in the child process rather than the proxy process

### DIFF
--- a/core/python2ActionLoop/lib/launcher.py
+++ b/core/python2ActionLoop/lib/launcher.py
@@ -20,6 +20,7 @@ import sys, os, codecs, json, traceback, warnings
 
 sys.stdout = codecs.getwriter('utf8')(sys.stdout)
 sys.stderr = codecs.getwriter('utf8')(sys.stderr)
+log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
 
 try:
   # if the directory 'virtualenv' is extracted out of a zip file
@@ -68,6 +69,8 @@ while True:
     res = {"error": str(ex)}
   out.write(json.dumps(res, ensure_ascii=False).encode('utf-8'))
   out.write(b'\n')
+  sys.stdout.write(log_sentinel)
+  sys.stderr.write(log_sentinel)
   sys.stdout.flush()
   sys.stderr.flush()
   out.flush()

--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -21,6 +21,8 @@ from sys import stderr
 from os import fdopen
 import sys, os, json, traceback, warnings
 
+log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
+
 try:
   # if the directory 'virtualenv' is extracted out of a zip file
   path_to_virtualenv = os.path.abspath('./virtualenv')
@@ -68,6 +70,8 @@ while True:
     res = {"error": str(ex)}
   out.write(json.dumps(res, ensure_ascii=False).encode('utf-8'))
   out.write(b'\n')
+  stdout.write(log_sentinel)
+  stderr.write(log_sentinel)
   stdout.flush()
   stderr.flush()
   out.flush()


### PR DESCRIPTION
To reflect the changes from https://github.com/nimbella/openwhisk-runtime-go/pull/4.