### PR TITLE
SERVERLESS-1465 Update Golang version to more recent one

### DIFF
--- a/core/python39Action/Dockerfile
+++ b/core/python39Action/Dockerfile
@@ -16,16 +16,17 @@
 #
 
 # build go proxy from source
-FROM golang:1.16 AS builder_source
+ARG GO_PROXY_BASE_IMAGE=golang:1.18
+FROM $GO_PROXY_BASE_IMAGE AS builder_source
 ARG GO_PROXY_GITHUB_USER=nimbella-corp
 ARG GO_PROXY_GITHUB_BRANCH=dev
 RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} \
-   https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
-   cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
-   mv proxy /bin/proxy
+  https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src ;\
+  cd /src ; env GO111MODULE=on CGO_ENABLED=0 go build main/proxy.go && \
+  mv proxy /bin/proxy
 
 # or build it from a release
-FROM golang:1.16 AS builder_release
+FROM $GO_PROXY_BASE_IMAGE AS builder_release
 ARG GO_PROXY_RELEASE_VERSION=1.16@1.18.0
 RUN curl -sL \
   https://github.com/apache/openwhisk-runtime-go/archive/{$GO_PROXY_RELEASE_VERSION}.tar.gz\


### PR DESCRIPTION
Updates the Golang version used to build the go proxy and makes it dynamic so we can update this centrally in our build scripts in the future.