### PR TITLE
SERVERLESS-1395 Implement prelaunch behavior for the Python runtime

### DIFF
--- a/core/python39Action/Dockerfile
+++ b/core/python39Action/Dockerfile
@@ -55,6 +55,7 @@ COPY --from=builder_release /bin/proxy /bin/proxy_release
 RUN mv /bin/proxy_${GO_PROXY_BUILD_FROM} /bin/proxy
 ADD bin/compile /bin/compile
 ADD lib/launcher.py /lib/launcher.py
+ADD lib/prelauncher.py /lib/prelauncher.py
 
 # log initialization errors
 ENV OW_LOG_INIT_ERROR=1
@@ -64,5 +65,7 @@ ENV OW_WAIT_FOR_ACK=1
 #ENV OW_EXECUTION_ENV=openwhisk/action-python-v3.9
 # compiler script
 ENV OW_COMPILER=/bin/compile
+
+ENV OW_INIT_IN_ACTIONLOOP=/lib/prelauncher.py
 
 ENTRYPOINT ["/bin/proxy"]

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -1,0 +1,121 @@
+#!/usr/local/bin/python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import print_function
+from sys import stdin
+from sys import stdout
+from sys import stderr
+from os import fdopen
+import sys, os, json, traceback, base64, io, zipfile
+
+log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
+def write_sentinels():
+  stdout.write(log_sentinel)
+  stderr.write(log_sentinel)
+  stdout.flush()
+  stderr.flush()
+
+out = fdopen(3, "wb")
+def write_result(res):
+  out.write(json.dumps(res, ensure_ascii=False).encode('utf-8'))
+  out.write(b'\n')
+  out.flush()
+
+def cannot_start(msg):
+  stderr.write(msg)
+  write_result({"error": "Cannot start action. Check logs for details."})
+  write_sentinels()
+  sys.exit(1)
+
+# Notify the Golang proxy that the process is awaiting input.
+write_result({"ok": True})
+
+# Read the init payload.
+line = stdin.readline()
+init = json.loads(line)["value"]
+
+# Set the environment from the init payload.
+if init["env"]:
+  for key, value in init["env"].items():
+    if isinstance(value, str):
+      os.environ[key] = value
+    else:
+      # Anything that's not a string needs to be stringified.
+      os.environ[key] = json.dumps(value)
+
+if init["binary"]:
+  # We have a base64 encoded zip as code.
+  buffer = base64.b64decode(init["code"])
+  with zipfile.ZipFile(io.BytesIO(buffer)) as zip_ref:
+    zip_ref.extractall(".")
+
+  # Note: We're ignoring `exec` here as we don't need a starter script.
+  if os.path.exists("__main__.py"):
+    os.rename("__main__.py", "main__.py")
+  if not os.path.exists("main__.py"):
+    cannot_start("Zip file does not include '__main__.py'.\n")
+
+  try:
+    # If the directory 'virtualenv' is extracted out of a zip file.
+    path_to_virtualenv = os.path.abspath('virtualenv')
+    if os.path.isdir(path_to_virtualenv):
+      # Activate the virtualenv using activate_this.py contained in the virtualenv.
+      activate_this_file = path_to_virtualenv + '/bin/activate_this.py'
+      if not os.path.exists(activate_this_file): # try windows path
+        activate_this_file = path_to_virtualenv + '/Scripts/activate_this.py'
+      if os.path.exists(activate_this_file):
+        exec(open(activate_this_file).read(), {'__file__': activate_this_file})
+      else:
+        cannot_start("Invalid virtualenv: Zip file does not include 'activate_this.py'.\n")
+  except Exception as ex:
+    traceback.print_exc(file=stderr, limit=0)
+    cannot_start("Invalid virtualenv: Failed to active virtualenv %s.\n" % str(ex))
+else:
+  # TODO: We can optimize this further by compiling the code in-process.
+  with open("main__.py", mode="wb") as f:
+    f.write(init["code"].encode("utf-8"))
+
+# Import the action itself.
+try:
+  sys.path.append(os.getcwd())
+  main = getattr(__import__("main__", fromlist=[init["main"]]), init["main"])
+except Exception as ex:
+  cannot_start("Invalid action: %s\n" % str(ex))
+
+# Acknowledge the initialization.
+write_result({"ok": True})
+
+# Enter the actual action loop.
+while True:
+  line = stdin.readline()
+  if not line: break
+  args = json.loads(line)
+  payload = {}
+  for key in args:
+    if key == "value":
+      payload = args["value"]
+    else:
+      os.environ["__OW_%s" % key.upper()]= args[key]
+  res = {}
+  try:
+    res = main(payload)
+  except Exception as ex:
+    print(traceback.format_exc(), file=stderr)
+    res = {"error": str(ex)}
+  write_result(res)
+  write_sentinels()


### PR DESCRIPTION
As per title, this implements prelaunch mode for the python runtime to start the interpreter alongside the go proxy and initialize the respective function in that existing process.

# Benchmark results

## Run (and wait for server to be up)

| Command | Mean [ms] | Min [ms] | Max [ms] |
|:---|---:|---:|---:|
| `python / runsc / run and wait (HEAD)` | 530.1 ± 51.8 | 439.9 | 593.3 |
| `python / runsc / run and wait (in-process init)` | 701.0 ± 32.5 | 658.5 | 757.4 |

## /init

| Command | Mean [ms] | Min [ms] | Max [ms] |
|:---|---:|---:|---:|
| `python / runsc / init (minimal action, HEAD)` | 649.9 ± 98.3 | 562.0 | 891.2 |
| `python / runsc / init (minimal action, in-process init)` | 14.1 ± 1.1 | 13.2 | 16.2 |
| `python / runsc / init (bigger action, HEAD)` | 1.200 ± 0.034 | 1.138 | 1.244 |
| `python / runsc / init (bigger action, in-process init)` | 624.7 ± 42.7 | 586.3 | 730.5 |

## Setup

### Machine

- s-4vcpu-8gb-intel
- debian-10-x64
- fra1

### Minimal Action

```python
def main(): return {}
```

### Bigger Action

```python
import pyjokes

def main(args):
  joke = pyjokes.get_jokes(category='chuck')[0]
  return {
    'body': {
      'response_type': 'in_channel',
      'text': joke
    }
  }
```

# Test results

```
runtime.actionContainers.Python39Tests > runtime proxy should handle initialization with no code PASSED

runtime.actionContainers.Python39Tests > runtime proxy should handle initialization with no content PASSED

runtime.actionContainers.Python39Tests > runtime proxy should run and report an error for function not returning a json object PASSED

runtime.actionContainers.Python39Tests > runtime proxy should fail to initialize a second time PASSED

runtime.actionContainers.Python39Tests > runtime proxy should invoke non-standard entry point PASSED

runtime.actionContainers.Python39Tests > runtime proxy should echo arguments and print message to stdout/stderr PASSED

runtime.actionContainers.Python39Tests > runtime proxy should handle unicode in source, input params, logs, and result PASSED

runtime.actionContainers.Python39Tests > runtime proxy should export environment variables before initialization PASSED

runtime.actionContainers.Python39Tests > runtime proxy should confirm expected environment variables PASSED

runtime.actionContainers.Python39Tests > runtime proxy should echo a large input PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should support zip-encoded action using non-default entry points PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should support zip-encoded action which can read from relative paths PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should report error if zip-encoded action does not include required file PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should return on action error when action fails PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should log compilation errors PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should support application errors PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should error when importing a not-supported package FAILED
    org.scalatest.exceptions.TestFailedException: "Invalid action: No module named 'iamnotsupported'" did not include substring that matched regex Traceback|cannot start

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should have a valid sys.executable PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should detect termination at run FAILED
    org.scalatest.exceptions.TestFailedException: expected number of stdout sentinels: '' 1 was not equal to 0

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should detect termination at init FAILED
    org.scalatest.exceptions.TestFailedException: ""Cannot initialize action. Check logs for details."" did not include substring "Cannot start action"

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should read an environment variable PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should run zipped Python action containing a virtual environment PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should run zipped Python action containing a virtual environment with non-standard entry point PASSED

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should report error if zipped Python action has wrong main module name FAILED
    org.scalatest.exceptions.TestFailedException: ""The action did not initialize properly."" did not include substring that matched regex Cannot start action. Check logs for details.

runtime.actionContainers.Python39Tests > registry.digitalocean.com/markus-dev/action-python-v3.9 should report error if zipped Python action has invalid virtualenv directory FAILED
    org.scalatest.exceptions.TestFailedException: ""The action did not initialize properly."" did not include substring that matched regex Invalid virtualenv|action failed
```

There's a slight diff in how errors are surfaced to the user due to how the Golang proxy handles the different paths. I think that's fine'ish.