### PR TITLE
remove nim install

### DIFF
--- a/core/python39Action/Dockerfile
+++ b/core/python39Action/Dockerfile
@@ -43,12 +43,7 @@ ARG GO_PROXY_BUILD_FROM=release
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# install nim (to be retired once we are fully switched to using functions-deployer)
-ARG NIM_INSTALL_SCRIPT=
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl ${NIM_INSTALL_SCRIPT} | bash
-
-# install the functions-deployer (co-exist with nim temporarily)
+# install the functions-deployer
 ARG DEPLOYER_DOWNLOAD
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \


### PR DESCRIPTION
We previously added an install for the DigitalOcean functions deployer. The builder actions have been revised to invoke it instead of `nim`. This PR completes the switch-over by removing `nim`.