### PR TITLE
SERVERLESS-2327 Map environment into a context parameter

### DIFF
--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -50,6 +50,7 @@ class Context:
     self.function_name = env["__OW_ACTION_NAME"]
     self.function_version = env["__OW_ACTION_VERSION"]
     self.activation_id = env["__OW_ACTIVATION_ID"]
+    self.request_id = env["__OW_TRANSACTION_ID"]
     self.deadline = int(os.environ["__OW_DEADLINE"])
 
   def get_remaining_time_in_millis(self):

--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -51,7 +51,10 @@ class Context:
     self.function_version = env["__OW_ACTION_VERSION"]
     self.activation_id = env["__OW_ACTIVATION_ID"]
     self.request_id = env["__OW_TRANSACTION_ID"]
-    self.deadline = int(os.environ["__OW_DEADLINE"])
+    self.deadline = int(env["__OW_DEADLINE"])
+    self.api_host = env["__OW_API_HOST"]
+    self.api_key = env.get("__OW_AUTH_KEY", "")
+    self.namespace = env["__OW_NAMESPACE"]
 
   def get_remaining_time_in_millis(self):
     epoch_now_in_ms = int(time.time() * 1000)

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -102,6 +102,7 @@ class Context:
     self.function_name = env["__OW_ACTION_NAME"]
     self.function_version = env["__OW_ACTION_VERSION"]
     self.activation_id = env["__OW_ACTIVATION_ID"]
+    self.request_id = env["__OW_TRANSACTION_ID"]
     self.deadline = int(os.environ["__OW_DEADLINE"])
 
   def get_remaining_time_in_millis(self):

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -103,7 +103,10 @@ class Context:
     self.function_version = env["__OW_ACTION_VERSION"]
     self.activation_id = env["__OW_ACTIVATION_ID"]
     self.request_id = env["__OW_TRANSACTION_ID"]
-    self.deadline = int(os.environ["__OW_DEADLINE"])
+    self.deadline = int(env["__OW_DEADLINE"])
+    self.api_host = env["__OW_API_HOST"]
+    self.api_key = env.get("__OW_AUTH_KEY", "")
+    self.namespace = env["__OW_NAMESPACE"]
 
   def get_remaining_time_in_millis(self):
     epoch_now_in_ms = int(time.time() * 1000)

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -21,7 +21,7 @@ from sys import stdin
 from sys import stdout
 from sys import stderr
 from os import fdopen
-import sys, os, json, traceback, base64, io, zipfile
+import sys, os, json, traceback, base64, io, zipfile, time
 
 log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
 def write_sentinels():
@@ -97,6 +97,26 @@ try:
 except Exception as ex:
   cannot_start("Invalid action: %s\n" % str(ex))
 
+class Context:
+  def __init__(self, env):
+    self.function_name = env["__OW_ACTION_NAME"]
+    self.function_version = env["__OW_ACTION_VERSION"]
+    self.activation_id = env["__OW_ACTIVATION_ID"]
+    self.deadline = int(os.environ["__OW_DEADLINE"])
+
+  def get_remaining_time_in_millis(self):
+    epoch_now_in_ms = int(time.time() * 1000)
+    delta_ms = self.deadline - epoch_now_in_ms
+    return delta_ms if delta_ms > 0 else 0
+
+def fun(payload, env):
+  # Compatibility: Supports "old" context-less functions.
+  if main.__code__.co_argcount == 1:
+    return main(payload)
+
+  # Lambda-like "new-style" function.
+  return main(payload, Context(env))
+
 # Acknowledge the initialization.
 write_result({"ok": True})
 
@@ -113,7 +133,7 @@ while True:
       os.environ["__OW_%s" % key.upper()]= args[key]
   res = {}
   try:
-    res = main(payload)
+    res = fun(payload, os.environ)
   except Exception as ex:
     print(traceback.format_exc(), file=stderr)
     res = {"error": str(ex)}

--- a/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
@@ -99,7 +99,7 @@ trait PythonAdvancedTests {
     "non-prelaunched" -> Map("OW_INIT_IN_ACTIONLOOP" -> ""),
   ).foreach { case (name, env) =>
     it should s"support a function with a lambda-like signature $name" in {
-      val (out, err) = withActionContainer(env) { c =>
+      val (out, err) = withActionContainer(env + ("__OW_API_HOST" -> "testhost")) { c =>
         val code =
           """
             |def main(event, context):
@@ -108,7 +108,10 @@ trait PythonAdvancedTests {
             |      "activation_id": context.activation_id,
             |      "request_id": context.request_id,
             |      "function_name": context.function_name,
-            |      "function_version": context.function_version
+            |      "function_version": context.function_version,
+            |      "api_host": context.api_host,
+            |      "api_key": context.api_key,
+            |      "namespace": context.namespace
             |   }
           """.stripMargin
 
@@ -122,7 +125,9 @@ trait PythonAdvancedTests {
             "activation_id" -> "testaid".toJson,
             "transaction_id" -> "testtid".toJson,
             "action_name" -> "testfunction".toJson,
-            "action_version" -> "0.0.1".toJson
+            "action_version" -> "0.0.1".toJson,
+            "namespace" -> "testnamespace".toJson,
+            "auth_key" -> "testkey".toJson
           ))
         ))
         runCode should be(200)
@@ -134,7 +139,10 @@ trait PythonAdvancedTests {
           "activation_id" -> "testaid".toJson,
           "request_id" -> "testtid".toJson,
           "function_name" -> "testfunction".toJson,
-          "function_version" -> "0.0.1".toJson
+          "function_version" -> "0.0.1".toJson,
+          "api_host" -> "testhost".toJson,
+          "api_key" -> "testkey".toJson,
+          "namespace" -> "testnamespace".toJson
         ))
       }
     }

--- a/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
@@ -106,6 +106,7 @@ trait PythonAdvancedTests {
             |   return {
             |      "remaining_time": context.get_remaining_time_in_millis(),
             |      "activation_id": context.activation_id,
+            |      "request_id": context.request_id,
             |      "function_name": context.function_name,
             |      "function_version": context.function_version
             |   }
@@ -118,7 +119,8 @@ trait PythonAdvancedTests {
           JsObject(),
           Some(JsObject(
             "deadline" -> Instant.now.plusSeconds(10).toEpochMilli.toString.toJson,
-            "activation_id" -> "testid".toJson,
+            "activation_id" -> "testaid".toJson,
+            "transaction_id" -> "testtid".toJson,
             "action_name" -> "testfunction".toJson,
             "action_version" -> "0.0.1".toJson
           ))
@@ -129,7 +131,8 @@ trait PythonAdvancedTests {
         remainingTime should be > 9500 // We give the test 500ms of slack to invoke the function to avoid flakes.
         out shouldBe Some(JsObject(
           "remaining_time" -> remainingTime.toJson,
-          "activation_id" -> "testid".toJson,
+          "activation_id" -> "testaid".toJson,
+          "request_id" -> "testtid".toJson,
           "function_name" -> "testfunction".toJson,
           "function_version" -> "0.0.1".toJson
         ))

--- a/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
@@ -16,7 +16,8 @@
  */
 package runtime.actionContainers
 
-import spray.json.{JsObject, JsString}
+import spray.json._
+import spray.json.DefaultJsonProtocol._
 
 trait PythonAdvancedTests {
   this: PythonBasicTests =>
@@ -90,5 +91,46 @@ trait PythonAdvancedTests {
         o should include("xyz")
         e shouldBe empty
     })
+  }
+
+  Map(
+    "prelaunched" -> Map.empty[String, String],
+    "non-prelaunched" -> Map("OW_INIT_IN_ACTIONLOOP" -> ""),
+  ).foreach { case (name, env) =>
+    it should s"support a function with a lambda-like signature $name" in {
+      val (out, err) = withActionContainer(env) { c =>
+        val code =
+          """
+            |def main(event, context):
+            |   return {
+            |      "remaining_time": context.get_remaining_time_in_millis(),
+            |      "activation_id": context.activation_id,
+            |      "function_name": context.function_name,
+            |      "function_version": context.function_version
+            |   }
+          """.stripMargin
+
+        val (initCode, _) = c.init(initPayload(code))
+        initCode should be(200)
+
+        val (runCode, out) = c.run(runPayload(
+          JsObject(),
+          Some(JsObject(
+            "deadline" -> "0".toJson,
+            "activation_id" -> "testid".toJson,
+            "action_name" -> "testfunction".toJson,
+            "action_version" -> "0.0.1".toJson
+          ))
+        ))
+        runCode should be(200)
+
+        out shouldBe Some(JsObject(
+          "remaining_time" -> 0.toJson, // This being 0 proofs that the function exists and is callable at least.
+          "activation_id" -> "testid".toJson,
+          "function_name" -> "testfunction".toJson,
+          "function_version" -> "0.0.1".toJson
+        ))
+      }
+    }
   }
 }


### PR DESCRIPTION
This translates our current environment variable based approach into passing a second "context" parameter to the function. The context somewhat resembles Lambda's context parameter but notably keeps the notion of an "activation_id" as that's still an entity we use in our docs and API.