### PR TITLE
SERVERLESS-2327 Map environment into a context parameter and mangle HTTP request

### DIFF
--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -19,7 +19,8 @@ from sys import stdin
 from sys import stdout
 from sys import stderr
 from os import fdopen
-import sys, os, json, traceback, warnings
+import sys, os, json, traceback, time
+from urllib.parse import parse_qs
 
 log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
 
@@ -45,6 +46,53 @@ except Exception:
 # now import the action as process input/output
 from main__ import main as main
 
+class Context:
+  def __init__(self, env):
+    self.function_name = env["__OW_ACTION_NAME"]
+    self.function_version = env["__OW_ACTION_VERSION"]
+    self.activation_id = env["__OW_ACTIVATION_ID"]
+    self.deadline = int(os.environ["__OW_DEADLINE"])
+
+  def get_remaining_time_in_millis(self):
+    epoch_now_in_ms = int(time.time() * 1000)
+    delta_ms = self.deadline - epoch_now_in_ms
+    return delta_ms if delta_ms > 0 else 0
+
+def fun(payload, env):
+  # Compatibility: Supports "old" context-less functions.
+  if main.__code__.co_argcount == 1:
+    return main(payload)
+
+  # Lambda-like "new-style" function.
+
+  # Transform the HTTP event to avoid leaking __ow_ details.
+  # See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format.
+  for k in ['__ow_path', '__ow_method', '__ow_headers', '__ow_body', '__ow_isBase64Encoded']:
+    if k in payload:
+      val = payload[k]
+      newKey = k[5:] # Drop the __ow_ prefix.
+
+      if newKey == 'method':
+        newKey = 'httpMethod'
+        val = val.upper()
+
+      payload[newKey] = val
+      del payload[k]
+  
+  if '__ow_query' in payload:
+    qs = payload['__ow_query']
+    parsed = parse_qs(qs) # These are of the form of {k:[v...]}
+    flattened = {k:v[0] for (k,v) in parsed.items()} # These are of the form {k:v}
+
+    # There can be more than one value for a given query string parameter, so we provide both the
+    # "correct" parsed query string and a convenience version that's flattened and assumes just
+    # one value per key.
+    payload['multiValueQueryStringParameters'] = parsed
+    payload['queryStringParameters'] = flattened
+    del payload['__ow_query']
+
+  return main(payload, Context(env))
+
 out = fdopen(3, "wb")
 if os.getenv("__OW_WAIT_FOR_ACK", "") != "":
     out.write(json.dumps({"ok": True}, ensure_ascii=False).encode('utf-8'))
@@ -64,7 +112,7 @@ while True:
       env["__OW_%s" % key.upper()]= args[key]
   res = {}
   try:
-    res = main(payload)
+    res = fun(payload, env)
   except Exception as ex:
     print(traceback.format_exc(), file=stderr)
     res = {"error": str(ex)}

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -21,7 +21,8 @@ from sys import stdin
 from sys import stdout
 from sys import stderr
 from os import fdopen
-import sys, os, json, traceback, base64, io, zipfile
+import sys, os, json, traceback, base64, io, zipfile, time
+from urllib.parse import parse_qs
 
 log_sentinel="XXX_THE_END_OF_A_WHISK_ACTIVATION_XXX\n"
 def write_sentinels():
@@ -97,6 +98,53 @@ try:
 except Exception as ex:
   cannot_start("Invalid action: %s\n" % str(ex))
 
+class Context:
+  def __init__(self, env):
+    self.function_name = env["__OW_ACTION_NAME"]
+    self.function_version = env["__OW_ACTION_VERSION"]
+    self.activation_id = env["__OW_ACTIVATION_ID"]
+    self.deadline = int(os.environ["__OW_DEADLINE"])
+
+  def get_remaining_time_in_millis(self):
+    epoch_now_in_ms = int(time.time() * 1000)
+    delta_ms = self.deadline - epoch_now_in_ms
+    return delta_ms if delta_ms > 0 else 0
+
+def fun(payload, env):
+  # Compatibility: Supports "old" context-less functions.
+  if main.__code__.co_argcount == 1:
+    return main(payload)
+
+  # Lambda-like "new-style" function.
+
+  # Transform the HTTP event to avoid leaking __ow_ details.
+  # See https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-input-format.
+  for k in ['__ow_path', '__ow_method', '__ow_headers', '__ow_body', '__ow_isBase64Encoded']:
+    if k in payload:
+      val = payload[k]
+      newKey = k[5:] # Drop the __ow_ prefix.
+
+      if newKey == 'method':
+        newKey = 'httpMethod'
+        val = val.upper()
+
+      payload[newKey] = val
+      del payload[k]
+  
+  if '__ow_query' in payload:
+    qs = payload['__ow_query']
+    parsed = parse_qs(qs) # These are of the form of {k:[v...]}
+    flattened = {k:v[0] for (k,v) in parsed.items()} # These are of the form {k:v}
+
+    # There can be more than one value for a given query string parameter, so we provide both the
+    # "correct" parsed query string and a convenience version that's flattened and assumes just
+    # one value per key.
+    payload['multiValueQueryStringParameters'] = parsed
+    payload['queryStringParameters'] = flattened
+    del payload['__ow_query']
+
+  return main(payload, Context(env))
+
 # Acknowledge the initialization.
 write_result({"ok": True})
 
@@ -113,7 +161,7 @@ while True:
       os.environ["__OW_%s" % key.upper()]= args[key]
   res = {}
   try:
-    res = main(payload)
+    res = fun(payload, os.environ)
   except Exception as ex:
     print(traceback.format_exc(), file=stderr)
     res = {"error": str(ex)}


### PR DESCRIPTION
**Note:** This is an extended version of #11. I'm fine shipping this in piecemeal.

---

This translates our current environment variable based approach into passing a second "context" parameter to the function. The context somewhat resembles Lambda's context parameter but notably keeps the notion of an "activation_id" as that's still an entity we use in our docs and API.

In addition, this implements translation of an HTTP-based event to resemble Lambda's API Gateway event as well. It somewhat closely matches how we do the translation in our Node.js-based Lambda support with the addition of handling the query-string better (which we should probably fix in Node.js as well).