### PR TITLE
Align akka dependencies to allow us to run tests

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -34,13 +34,10 @@ gradle.ext.scala = [
     compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
 ]
 
-gradle.ext.akka = [version : '2.6.12']
-gradle.ext.akka_http = [version : '10.2.4']
-
 gradle.ext.scalafmt = [
     version: '1.5.0',
     config: new File(rootProject.projectDir, '.scalafmt.conf')
 ]
 
-gradle.ext.akka = [version: '2.6.12']
-gradle.ext.akka_http = [version: '10.2.4']
+gradle.ext.akka = [version: '2.5.32']
+gradle.ext.akka_http = [version: '10.1.15']


### PR DESCRIPTION
This aligns the akka dependencies with what we're using in our "main" repository. This is required to run the Scala-based tests in this repository.