### PR TITLE
Fix the env name to __OW_API_KEY

### DIFF
--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -53,7 +53,7 @@ class Context:
     self.request_id = env["__OW_TRANSACTION_ID"]
     self.deadline = int(env["__OW_DEADLINE"])
     self.api_host = env["__OW_API_HOST"]
-    self.api_key = env.get("__OW_AUTH_KEY", "")
+    self.api_key = env.get("__OW_API_KEY", "")
     self.namespace = env["__OW_NAMESPACE"]
 
   def get_remaining_time_in_millis(self):

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -105,7 +105,7 @@ class Context:
     self.request_id = env["__OW_TRANSACTION_ID"]
     self.deadline = int(env["__OW_DEADLINE"])
     self.api_host = env["__OW_API_HOST"]
-    self.api_key = env.get("__OW_AUTH_KEY", "")
+    self.api_key = env.get("__OW_API_KEY", "")
     self.namespace = env["__OW_NAMESPACE"]
 
   def get_remaining_time_in_millis(self):

--- a/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
@@ -127,7 +127,7 @@ trait PythonAdvancedTests {
             "action_name" -> "testfunction".toJson,
             "action_version" -> "0.0.1".toJson,
             "namespace" -> "testnamespace".toJson,
-            "auth_key" -> "testkey".toJson
+            "api_key" -> "testkey".toJson
           ))
         ))
         runCode should be(200)


### PR DESCRIPTION
Not sure why I was so dense and thought this was `__OW_AUTH_KEY`. See https://github.internal.digitalocean.com/serverless/main/blob/a512e51cb472cf23260638ce1a7826dfd51d0061/repos/openwhisk/tests/src/test/scala/actionContainers/BasicActionRunnerTests.scala#L100-L108 for confirmation that it's not.