### PR TITLE
SERVERLESS-2388 Functions missing signature and return type options for Python

### DIFF
--- a/core/python3Action/lib/launcher.py
+++ b/core/python3Action/lib/launcher.py
@@ -62,12 +62,17 @@ class Context:
     return delta_ms if delta_ms > 0 else 0
 
 def fun(payload, env):
+  # Compatibility: Supporting "old" context-less functions that have no params
+  # to match other languages.
+  if main.__code__.co_argcount == 0:
+    return main() or {}
+    
   # Compatibility: Supports "old" context-less functions.
   if main.__code__.co_argcount == 1:
-    return main(payload)
+    return main(payload) or {}
 
   # Lambda-like "new-style" function.
-  return main(payload, Context(env))
+  return main(payload, Context(env)) or {}
 
 out = fdopen(3, "wb")
 if os.getenv("__OW_WAIT_FOR_ACK", "") != "":

--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -114,12 +114,17 @@ class Context:
     return delta_ms if delta_ms > 0 else 0
 
 def fun(payload, env):
+  # Compatibility: Supporting "old" context-less functions that have no params
+  # to match other languages.
+  if main.__code__.co_argcount == 0:
+    return main() or {}
+
   # Compatibility: Supports "old" context-less functions.
   if main.__code__.co_argcount == 1:
-    return main(payload)
+    return main(payload) or {}
 
   # Lambda-like "new-style" function.
-  return main(payload, Context(env))
+  return main(payload, Context(env)) or {}
 
 # Acknowledge the initialization.
 write_result({"ok": True})


### PR DESCRIPTION
Add support for function signatures - no param and returning nothing.

All of our other runtimes support having a function that has no parameters. They also support having a function that returns nothing. In the case where nothing is returned by the function, the runtime returns an empty dictionary to the rest of the OpenWhisk system. This changes he Python runtime to match that behavior.

Tests were added in the serverless/main repo.