### PR TITLE
SERVERLESS-2491 Rename action -> function in error messages

### DIFF
--- a/core/python3Action/lib/prelauncher.py
+++ b/core/python3Action/lib/prelauncher.py
@@ -38,7 +38,7 @@ def write_result(res):
 
 def cannot_start(msg):
   stderr.write(msg)
-  write_result({"error": "Cannot start action. Check logs for details."})
+  write_result({"error": "Cannot start function. Check logs for details."})
   write_sentinels()
   sys.exit(1)
 
@@ -95,7 +95,7 @@ try:
   sys.path.append(os.getcwd())
   main = getattr(__import__("main__", fromlist=[init["main"]]), init["main"])
 except Exception as ex:
-  cannot_start("Invalid action: %s\n" % str(ex))
+  cannot_start("Invalid function: %s\n" % str(ex))
 
 class Context:
   def __init__(self, env):

--- a/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/PythonAdvancedTests.scala
@@ -60,7 +60,7 @@ trait PythonAdvancedTests {
       // action loop detects those errors at init time
       val (initCode, initRes) = c.init(initPayload(code))
       initCode should be(502)
-      initRes.get.fields.get("error").get.toString() should include("Cannot start action")
+      initRes.get.fields.get("error").get.toString() should include("Cannot start function")
     }
     checkStreams(out, err, {
       case (o, e) =>


### PR DESCRIPTION
As per title, to be able to eliminate action terminology from error messages.