### PR TITLE
SERVERLESS-2773 Add a Python 3.11 runtime

### DIFF
--- a/core/python311Action/Dockerfile
+++ b/core/python311Action/Dockerfile
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# build go proxy from source
+ARG GO_PROXY_BASE_IMAGE=golang:1.20
+FROM $GO_PROXY_BASE_IMAGE AS builder
+ARG GO_PROXY_GITHUB_USER=nimbella-corp
+ARG GO_PROXY_GITHUB_BRANCH=dev
+RUN git clone --branch ${GO_PROXY_GITHUB_BRANCH} https://github.com/${GO_PROXY_GITHUB_USER}/openwhisk-runtime-go /src \
+  && cd /src \
+  && env GO111MODULE=on CGO_ENABLED=0 go build -o /bin/proxy main/proxy.go
+
+FROM python:3.11-slim-bullseye
+
+# select the builder to use
+ARG GO_PROXY_BUILD_FROM=release
+
+# Install common modules for python
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# install the functions-deployer
+ARG DEPLOYER_DOWNLOAD
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && curl -L ${DEPLOYER_DOWNLOAD} | tar xzf - \
+  && rm -fr /usr/local/lib/dosls && mv dosls /usr/local/lib \
+  && rm -f /usr/local/bin/dosls && ln -s /usr/local/lib/dosls/bootstrap /usr/local/bin/dosls \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /action
+WORKDIR /
+COPY bin/compile /bin/compile
+COPY lib/launcher.py /lib/launcher.py
+COPY lib/prelauncher.py /lib/prelauncher.py
+
+# log initialization errors
+ENV OW_LOG_INIT_ERROR=1
+# the launcher must wait for an ack
+ENV OW_WAIT_FOR_ACK=1
+# using the runtime name to identify the execution environment
+#ENV OW_EXECUTION_ENV=openwhisk/action-python-v3.9
+# compiler script
+ENV OW_COMPILER=/bin/compile
+
+ENV OW_INIT_IN_ACTIONLOOP=/lib/prelauncher.py
+
+COPY --from=builder /bin/proxy /bin/proxy
+ENTRYPOINT ["/bin/proxy"]

--- a/core/python311Action/build.gradle
+++ b/core/python311Action/build.gradle
@@ -15,30 +15,24 @@
  * limitations under the License.
  */
 
-include 'tests'
+ext.dockerImageName = 'action-python-v3.11'
+apply from: '../../gradle/docker.gradle'
 
-include 'core:python2ActionLoop'
-include 'core:python3Action'
-include 'core:python36AiAction'
-include 'core:python39Action'
-include 'core:python311Action'
+distDocker.dependsOn 'copyLib'
+distDocker.dependsOn 'copyBin'
+distDocker.finalizedBy('cleanup')
 
-rootProject.name = 'runtime-python'
+task copyLib(type: Copy) {
+    from '../python3Action/lib'
+    into './lib'
+}
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
+task copyBin(type: Copy) {
+    from '../python3Action/bin'
+    into './bin'
+}
 
-gradle.ext.scala = [
-    version: '2.12.10',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
-
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
-
-gradle.ext.akka = [version: '2.5.32']
-gradle.ext.akka_http = [version: '10.1.15']
+task cleanup(type: Delete) {
+    delete 'bin'
+    delete 'lib'
+}

--- a/tests/src/test/resources/build.sh
+++ b/tests/src/test/resources/build.sh
@@ -21,7 +21,7 @@ if [ -f ".built" ]; then
   exit 0
 fi
 
-for i in v3.7 v3.6-ai v3.9
+for i in v3.7 v3.6-ai v3.9 v3.11
 do echo "*** $i ***"
    zip -r -j - python_virtualenv | docker run -i action-python-$i -compile main >python-${i}_virtualenv.zip
    cp python-${i}_virtualenv.zip python-${i}_virtualenv_invalid_main.zip

--- a/tests/src/test/scala/runtime/actionContainers/Python311Tests.scala
+++ b/tests/src/test/scala/runtime/actionContainers/Python311Tests.scala
@@ -15,30 +15,19 @@
  * limitations under the License.
  */
 
-include 'tests'
+package runtime.actionContainers
 
-include 'core:python2ActionLoop'
-include 'core:python3Action'
-include 'core:python36AiAction'
-include 'core:python39Action'
-include 'core:python311Action'
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
 
-rootProject.name = 'runtime-python'
+@RunWith(classOf[JUnitRunner])
+class Python311Tests extends Python37Tests {
 
-gradle.ext.openwhisk = [
-        version: '1.0.0-SNAPSHOT'
-]
+  override lazy val imageName = "action-python-v3.11"
 
-gradle.ext.scala = [
-    version: '2.12.10',
-    depVersion  : '2.12',
-    compileFlags: ['-feature', '-unchecked', '-deprecation', '-Xfatal-warnings', '-Ywarn-unused-import']
-]
+  override lazy val zipPrefix = "python-v3.11"
 
-gradle.ext.scalafmt = [
-    version: '1.5.0',
-    config: new File(rootProject.projectDir, '.scalafmt.conf')
-]
+  override lazy val errorCodeOnRun = false
 
-gradle.ext.akka = [version: '2.5.32']
-gradle.ext.akka_http = [version: '10.1.15']
+  override val testNoSource = TestConfig("", hasCodeStub = false)
+}


### PR DESCRIPTION
This adds Python 3.11. It's mostly a 1:1 copy with the only notable change being that this uses the "slim" variant of the base image.